### PR TITLE
Allow nil comparison in scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# 0.10.1 (June 19th, 2023)
+
+* Allow nil comparison in scopes - [#132](https://github.com/Gravity-Core/graphism/pull/132)
+
 # 0.10.0 (December 10th, 2022)
 
 * Policies - [#131](https://github.com/Gravity-Core/graphism/pull/131)

--- a/lib/graphism/policy.ex
+++ b/lib/graphism/policy.ex
@@ -63,6 +63,7 @@ defmodule Graphism.Policy do
     %{app: app, env: Module.concat(env), key: key}
   end
 
+  defp value(nil), do: {:literal, nil}
   defp value(v) when is_boolean(v), do: {:literal, v}
   defp value({:literal, _, [v]}), do: {:literal, v}
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.10.0",
+      version: "0.10.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Supports expressions in the form:

```
scope property_unset do
  some_property == nil
end
```

where we can test against `nil`.