### PR TITLE
Not-equal comparison syntax sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# 0.10.2 (June 22th, 2023)
+
+* Not-equal comparison syntax sugar - [#133](https://github.com/Gravity-Core/graphism/pull/133)
+
 # 0.10.1 (June 19th, 2023)
 
 * Allow nil comparison in scopes - [#132](https://github.com/Gravity-Core/graphism/pull/132)

--- a/lib/graphism/policy.ex
+++ b/lib/graphism/policy.ex
@@ -35,6 +35,7 @@ defmodule Graphism.Policy do
   end
 
   defp op(:==), do: :eq
+  defp op(:!=), do: :neq
   defp op(op) when is_atom(op), do: op
   defp op(other), do: raise("scope operator #{inspect(other)} is not supported")
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.10.1",
+      version: "0.10.2",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Supports the `!=` operator in scope expressions. Eg:

```elixir
scope :is_leaf do
  parent != nil
end
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
