### PR TITLE
Better support for :neq in comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Unreleased
 
+# 0.10.3 (June 22th, 2023)
+
+* Better support for :neq in comparisons - [#139](https://github.com/Gravity-Core/graphism/pull/139)
+
 # 0.10.2 (June 22th, 2023)
 
-* Not-equal comparison syntax sugar - [#133](https://github.com/Gravity-Core/graphism/pull/133)
+* Not-equal comparison syntax sugar - [#138](https://github.com/Gravity-Core/graphism/pull/138)
 
 # 0.10.1 (June 19th, 2023)
 
-* Allow nil comparison in scopes - [#132](https://github.com/Gravity-Core/graphism/pull/132)
+* Allow nil comparison in scopes - [#137](https://github.com/Gravity-Core/graphism/pull/137)
 
 # 0.10.0 (December 10th, 2022)
 

--- a/lib/graphism/querying.ex
+++ b/lib/graphism/querying.ex
@@ -225,6 +225,8 @@ defmodule Graphism.Querying do
 
   def compare_fun do
     quote do
+      def compare(v, v, :neq), do: false
+      def compare(_, _, :neq), do: true
       def compare(nil, nil, _), do: true
       def compare(nil, _, _), do: false
       def compare(v, v, :eq), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.10.2",
+      version: "0.10.3",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

The :neq operator was not properly supported in the comparator api.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
