### PR TITLE
Set nil on parent deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Set nil on parent deletes - [#141](https://github.com/Gravity-Core/graphism/pull/141)
+
 # 0.11.0 (June 22th, 2023)
 
 * Do not nullify optional relations on updates by default - [#140](https://github.com/Gravity-Core/graphism/pull/140)

--- a/README.md
+++ b/README.md
@@ -558,6 +558,16 @@ end
 Graphism will take of writing the correct migrations, including dropping existing constraints, in order to fully support
 changes in this policy.
 
+For optional parent relations, it is possible to nullify the value pointed at with:
+
+```elixir
+entity :node do
+  ...
+  maybe_belongs_to(:node, as: parent, delete: :set_nil)
+  ...
+end
+```
+
 ### Schema introspection
 
 Sometimes you might need to be able to instrospect your schema in a programmatic way. Graphism generates

--- a/lib/migrations.ex
+++ b/lib/migrations.ex
@@ -207,6 +207,7 @@ defmodule Graphism.Migrations do
   defp on_delete_column_opt(rel) do
     case get_in(rel, [:opts, :delete]) do
       :cascade -> :delete_all
+      :set_nil -> :nilify_all
       nil -> :nothing
     end
   end


### PR DESCRIPTION
### Description

Adds support for this notation:

```elixir
entity :node do
  ...
  maybe_belongs_to(:node, as: parent, delete: :set_nil)
  ...
end
```

which translates into a `on_delete: :nilify_all` in the generated ecto migration.


### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
