### PR TITLE
Policy evaluation debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Set nil on parent deletes - [#141](https://github.com/Gravity-Core/graphism/pull/141)
+* Policy evaluation debug logs - [#142](https://github.com/Gravity-Core/graphism/pull/142)
 
 # 0.11.0 (June 22th, 2023)
 

--- a/lib/graphism/auth.ex
+++ b/lib/graphism/auth.ex
@@ -121,6 +121,10 @@ defmodule Graphism.Auth do
         end)
       end
 
+      @debug Application.compile_env(:graphism, :debug)
+
+      require Logger
+
       defp do_policy_allow?(%{prop: prop_spec, value: value_spec, op: op}, args, context, paths) do
         context = Map.put(context, :args, args)
 
@@ -140,15 +144,20 @@ defmodule Graphism.Auth do
         value = evaluate(context, value_spec)
         result = compare(prop, value, op)
 
-        #IO.inspect(
-        #  paths: paths,
-        #  context: context,
-        #  prop_spec: prop_spec,
-        #  prop: prop,
-        #  value_spec: value_spec,
-        #  value: value,
-        #  result: result
-        #)
+        if @debug do
+          info = [
+            paths: paths,
+            context: context,
+            prop_spec: prop_spec,
+            prop: prop,
+            value_spec: value_spec,
+            value: value,
+            result: result,
+            op: op
+          ]
+
+          Logger.debug("graphism do_policy_allow?/4: #{inspect(info, pretty: true)}")
+        end
 
         result
       end


### PR DESCRIPTION
### Description

Adds debug logging to the policy evaluations. Sometimes it might be tricky to understand why a scope is allowing or denying access. This should make it easier troubleshoot things. In your `config.exs`, turn this feature on:

```elixir
config :graphism,
  debug: true,  # <- set this to true
  schema:  ...
```

Configure your log level so that `debug` is enabled too. Then you should start seeing log entries such as: 

```
[debug] graphism policy allow: [
  paths: [:node, :parent],
  context: %{
    analytic: %{user: %{roles: [:anonymous]}},
    args: %{name: "notion"},
    node: %AnalyticWeb.Schema.Node{
      __meta__: #Ecto.Schema.Metadata<:loaded, "nodes">,
      id: "ae98f531-6d0f-4ffb-b4a1-b9168cc69d49",
      name: "notion",
      parent_id: "61d67aa4-7e0d-4630-8058-d82ce80fa15f",
      parent: #Ecto.Association.NotLoaded<association :parent is not loaded>,
      inserted_at: ~U[2023-07-05 16:29:37Z],
      updated_at: ~U[2023-07-05 16:41:06Z]
    },
    parent: %AnalyticWeb.Schema.Node{
      __meta__: #Ecto.Schema.Metadata<:loaded, "nodes">,
      id: "ae98f531-6d0f-4ffb-b4a1-b9168cc69d49",
      name: "notion",
      parent_id: "61d67aa4-7e0d-4630-8058-d82ce80fa15f",
      parent: #Ecto.Association.NotLoaded<association :parent is not loaded>,
      inserted_at: ~U[2023-07-05 16:29:37Z],
      updated_at: ~U[2023-07-05 16:41:06Z]
    }
  },
  prop_spec: [:node, :parent],
  prop: %AnalyticWeb.Schema.Node{
    __meta__: #Ecto.Schema.Metadata<:loaded, "nodes">,
    id: "61d67aa4-7e0d-4630-8058-d82ce80fa15f",
    name: "root",
    parent_id: "04d69f37-b6f7-4ffe-a133-ab1477d3f733",
    parent: #Ecto.Association.NotLoaded<association :parent is not loaded>,
    inserted_at: ~U[2023-07-04 16:12:59Z],
    updated_at: ~U[2023-07-04 16:12:59Z]
  },
  value_spec: [:parent],
  value: %AnalyticWeb.Schema.Node{
    __meta__: #Ecto.Schema.Metadata<:loaded, "nodes">,
    id: "ae98f531-6d0f-4ffb-b4a1-b9168cc69d49",
    name: "notion",
    parent_id: "61d67aa4-7e0d-4630-8058-d82ce80fa15f",
    parent: #Ecto.Association.NotLoaded<association :parent is not loaded>,
    inserted_at: ~U[2023-07-05 16:29:37Z],
    updated_at: ~U[2023-07-05 16:41:06Z]
  },
  result: false,
  op: :eq
]
```

Careful because this might get verbose. Make sure you don't enable this in production.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
