### PR TITLE
Smarter inline mutation input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Set nil on parent deletes - [#141](https://github.com/Gravity-Core/graphism/pull/141)
 * Policy evaluation debug logs - [#142](https://github.com/Gravity-Core/graphism/pull/142)
+* Smarter input types - [#143](https://github.com/Gravity-Core/graphism/pull/143)
 
 # 0.11.0 (June 22th, 2023)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.11.0",
+      version: "0.12.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Generates input types for inlined children creations in a slightly smarter way, by only skipping those relations that have the same name as the parent entity. Other relations, which might be aliased, are left in the input type.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
