### PR TITLE
Workaround truncated auth debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+# v0.12.1 (Nov 28th, 2023)
+
+* Workaround truncated auth debug - [#144](https://github.com/Gravity-Core/graphism/pull/144)
+
+# v0.12.0 (Nov 22nd, 2023)
+
 * Set nil on parent deletes - [#141](https://github.com/Gravity-Core/graphism/pull/141)
 * Policy evaluation debug logs - [#142](https://github.com/Gravity-Core/graphism/pull/142)
 * Smarter input types - [#143](https://github.com/Gravity-Core/graphism/pull/143)

--- a/lib/graphism/auth.ex
+++ b/lib/graphism/auth.ex
@@ -156,7 +156,7 @@ defmodule Graphism.Auth do
             op: op
           ]
 
-          Logger.debug("graphism do_policy_allow?/4: #{inspect(info, pretty: true, limit: :infinity)}")
+          IO.inspect(info, pretty: true, limit: :infinity)
         end
 
         result

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.12.0",
+      version: "0.12.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

It seems we are still getting truncated output when debugging auth policies

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
