### PR TITLE
Support for @ notation in scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# v0.13.0 (Nov 28th, 2023)
+
+* Support for @ notation in scopes - [#145](https://github.com/Gravity-Core/graphism/pull/145)
+
 # v0.12.1 (Nov 28th, 2023)
 
 * Workaround truncated auth debug - [#144](https://github.com/Gravity-Core/graphism/pull/144)

--- a/lib/graphism/auth.ex
+++ b/lib/graphism/auth.ex
@@ -129,16 +129,22 @@ defmodule Graphism.Auth do
         context = Map.put(context, :args, args)
 
         prop =
-          paths
-          |> Enum.reduce_while(nil, fn path, _ ->
-            case context |> Map.get(path) |> evaluate(prop_spec) do
-              nil -> {:cont, nil}
-              value -> {:halt, value}
-            end
-          end)
-          |> case do
-            nil -> evaluate(context, prop_spec)
-            prop -> prop
+          case prop_spec do
+            [:@ | path] ->
+              evaluate(context, path)
+
+            _ ->
+              paths
+              |> Enum.reduce_while(nil, fn path, _ ->
+                case context |> Map.get(path) |> evaluate(prop_spec) do
+                  nil -> {:cont, nil}
+                  value -> {:halt, value}
+                end
+              end)
+              |> case do
+                nil -> evaluate(context, prop_spec)
+                prop -> prop
+              end
           end
 
         value = evaluate(context, value_spec)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.12.1",
+      version: "0.13.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Supports @ notations in scopes

```elixir
scope :not_internal_channel_tag do
  "@.tag.internal" == false
end
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
