### PR TITLE
Fix ecto syntax for non nil values in schemas filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# v0.13.1 (Jan 23rd, 2024)
+
+* Fix ecto syntax for non nil values in schemas filters - [#146](https://github.com/Otion-Core/graphism/pull/146)
+
 # v0.13.0 (Nov 28th, 2023)
 
 * Support for @ notation in scopes - [#145](https://github.com/Gravity-Core/graphism/pull/145)

--- a/lib/graphism/schema.ex
+++ b/lib/graphism/schema.ex
@@ -334,6 +334,12 @@ defmodule Graphism.Schema do
                 where(q, [{^binding, e}], e.unquote(column_name) == ^id)
               end
 
+              def filter(q, unquote(rel[:name]), :neq, nil, opts) do
+                binding = Keyword.get(opts, :parent, unquote(rel[:name]))
+
+                where(q, [{^binding, e}], not is_nil(e.unquote(column_name)))
+              end
+
               def filter(q, unquote(rel[:name]), :neq, id, opts) do
                 binding = Keyword.get(opts, :parent, unquote(rel[:name]))
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.13.0",
+      version: "0.13.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

When generating schema filters, and testing for non nil values, the generated where clause was using a syntax that is not supported by ecto, which raises the following error:

```
** (ArgumentError) comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use is_nil/1 instead
        (ecto 3.9.1) lib/ecto/query/builder.ex:1030: Ecto.Query.Builder.not_nil!/1
        (analytic 0.1.0) lib/analytic_web/schema/schema.ex:1: AnalyticWeb.Schema.Database.filter/5
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
