### PR TITLE
Add support for the Time datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# v0.13.2 (Feb 9th, 2024)
+
+* Add support for the Time datatype - [#148](https://github.com/Otion-Core/graphism/pull/148)
+
 # v0.13.1 (Feb 6th, 2024)
 
 * Fix ecto syntax for non nil values in schemas filters - [#146](https://github.com/Otion-Core/graphism/pull/146)

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -406,6 +406,9 @@ defmodule Graphism do
   defmacro date(_name, _opts \\ []) do
   end
 
+  defmacro time(_name, _opts \\ []) do
+  end
+
   defmacro decimal(_name, _opts \\ []) do
   end
 

--- a/lib/graphism/entity.ex
+++ b/lib/graphism/entity.ex
@@ -758,6 +758,7 @@ defmodule Graphism.Entity do
   def attribute({:boolean, _, [name]}), do: attribute([name, :boolean])
   def attribute({:float, _, [name]}), do: attribute([name, :float])
   def attribute({:datetime, _, [name]}), do: attribute([name, :datetime])
+  def attribute({:time, _, [name]}), do: attribute([name, :time])
   def attribute({:date, _, [name]}), do: attribute([name, :date])
   def attribute({:decimal, _, [name]}), do: attribute([name, :decimal])
   def attribute({:upload, _, [name]}), do: attribute([name, :upload, [modifiers: [:virtual]]])
@@ -920,7 +921,7 @@ defmodule Graphism.Entity do
   end
 
   def with_action_args(opts, _entity_name) do
-    args  = opts[:args] || []
+    args = opts[:args] || []
 
     if opts[:produces] && Enum.empty?(args) && !action_of_kind?(opts, :list) do
       Keyword.put(opts, :args, [:id])
@@ -1127,7 +1128,8 @@ defmodule Graphism.Entity do
   def list_from(_, _), do: nil
 
   def list_from(name, opts, entity_name) do
-    opts = (opts || [])
+    opts =
+      (opts || [])
       |> Keyword.put(:kind, [:query, :read, :list])
       |> Keyword.put(:produces, {:list, entity_name})
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.13.1",
+      version: "0.13.2",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Adds support for the time datatype. This seems to be a native type in both postgres and graphql, so the implementation here is quite trivial.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
