### PR TITLE
Improved support for computed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Improved support for computed fields - [#149](https://github.com/Otion-Core/graphism/pull/149)
+
 # v0.13.2 (Feb 9th, 2024)
 
 * Add support for the Time datatype - [#148](https://github.com/Otion-Core/graphism/pull/148)

--- a/README.md
+++ b/README.md
@@ -226,12 +226,54 @@ Computed attributes are part of your schema, they are stored, and can also be qu
 
 However, since they are computed, they won't be included in your mutations, therefore it is not possible to modify their values explicitly.
 
+In order to set the initial value of a computed attribute, a `:before` or `:after` action hook can be used:
+
 ```elixir
 entity :post do
-  computed(boolean(:draft, default: true)
-  ...
+  computed(boolean(:draft))
+
+  action :create, before: [MarkAsDraft] do
+  end
 end
 ```
+
+Alternatively, a `:using` hook can be specified at the field level:
+
+```elixir
+entity :post do
+  computed(boolean(:draft), using: MarkAsDraft)
+end
+```
+
+### Computed relations
+
+Relations can also be declared as computed in two different ways, explicitly and implicitly. Explict computed relations are declared with a `:using` hook:
+
+```elixir
+entity :post do
+  belongs_to(:blog)
+  computed(belongs_to(:user), using: SetUserFromBlog)
+end
+```
+
+Alternatively, relations can also be implicitly populated from the context:
+
+```elixir
+entity :post do
+  belongs_to(:blog)
+  belongs_to(:user, from_context: [:current_user]])
+end
+```
+
+but also from other relations:
+
+```elixir
+entity :post do
+  belongs_to(:blog)
+  belongs_to(:user, from: :blog])
+end
+```
+
 
 ### Slugs
 

--- a/lib/graphism/entity.ex
+++ b/lib/graphism/entity.ex
@@ -740,10 +740,23 @@ defmodule Graphism.Entity do
     put_in(attr, [:opts, :modifiers], modifiers)
   end
 
+  def attribute({:computed, _, [opts, [using: {:__aliases__, _, using}]]}) do
+    with attr when not is_nil(attr) <- attribute(opts) do
+      modifiers = [:computed | get_in(attr, [:opts, :modifiers]) || []]
+      using = Module.concat(using)
+
+      attr
+      |> put_in([:opts, :modifiers], modifiers)
+      |> put_in([:opts, :using], using)
+    end
+  end
+
   def attribute({:computed, _, [opts]}) do
-    attr = attribute(opts)
-    modifiers = [:computed | get_in(attr, [:opts, :modifiers]) || []]
-    put_in(attr, [:opts, :modifiers], modifiers)
+    with attr when not is_nil(attr) <- attribute(opts) do
+      modifiers = [:computed | get_in(attr, [:opts, :modifiers]) || []]
+
+      put_in(attr, [:opts, :modifiers], modifiers)
+    end
   end
 
   def attribute({:private, _, [opts]}) do
@@ -887,6 +900,25 @@ defmodule Graphism.Entity do
     opts = rel[:opts] || []
     opts = Keyword.put(opts, :preloaded, true)
     Keyword.put(rel, :opts, opts)
+  end
+
+  def relation_from({:computed, _, [opts, [using: {:__aliases__, _, using}]]}) do
+    with rel when not is_nil(rel) <- relation_from(opts) do
+      modifiers = get_in(rel, [:opts, :modifiers]) || []
+      using = Module.concat(using)
+
+      rel
+      |> put_in([:opts, :modifiers], [:computed | modifiers])
+      |> put_in([:opts, :using], using)
+    end
+  end
+
+  def relation_from({:computed, _, [opts]}) do
+    with rel when not is_nil(rel) <- relation_from(opts) do
+      modifiers = get_in(rel, [:opts, :modifiers]) || []
+
+      put_in(rel, [:opts, :modifiers], [:computed | modifiers])
+    end
   end
 
   def relation_from(_), do: nil

--- a/lib/graphism/resolver.ex
+++ b/lib/graphism/resolver.ex
@@ -30,7 +30,7 @@ defmodule Graphism.Resolver do
       defmodule unquote(e[:resolver_module]) do
         (unquote_splicing(resolver_funs))
       end
-    end  |> Ast.print(e[:name] == :folder)
+    end
   end
 
   defp with_resolver_pagination_fun(funs) do
@@ -553,7 +553,7 @@ defmodule Graphism.Resolver do
               mod = rel[:opts][:using]
 
               quote do
-                {:ok, unquote(Ast.var(rel))} <- unquote(mod).execute(args, context)
+                {:ok, unquote(Ast.var(rel))} <- unquote(mod).execute(unquote(Ast.var(:args)), context)
               end
 
             rel[:opts][:from] != nil ->
@@ -575,7 +575,7 @@ defmodule Graphism.Resolver do
               end
 
             true ->
-              raise "relation #{rel[:name]} of #{e[:name]} is computed but does not specify a :using or a :from option"
+              raise "Relation #{inspect(rel[:name])} of entity #{inspect(e[:name])} is computed, but does not specify a :using or a :from option"
           end
 
         false ->
@@ -627,6 +627,7 @@ defmodule Graphism.Resolver do
                             {:ok, unquote(api_module).relation(unquote(Ast.var(e)), unquote(rel[:name]))}
                           end
                         end
+
                       _ ->
                         quote do
                           case Map.get(unquote(Ast.var(:args)), unquote(arg_name), nil) do


### PR DESCRIPTION
### Description

Improves support for computed attributes and relations. Computed relations where not being supported explicitly.

Now it is possible to add a `:using` hook to the field itself.  

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
