### PR TITLE
Bigint attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bigint attributes - [#153](https://github.com/Otion-Core/graphism/pull/153)
+
 # v0.14.0 (Feb 22nd, 2024)
 
 * Pass context to api functions - [#150](https://github.com/Otion-Core/graphism/pull/150)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,36 @@ Keep reading if you want to learn about all the features offered by Graphism...
 
 ## Schema Features
 
+### Attribute types
+
+The following attribute types are supported:
+
+* `string`
+* `text`
+* `integer`
+* `bigint`
+* `decimal`
+* `float`
+* `boolean`
+* `datetime`
+* `date`
+* `time`
+* `upload`
+* `json`
+* `slug`
+
+Each of these types offers its own macro, for example:
+
+```elixir
+entity :event do
+  string(:title)
+  text(:description)
+  boolean(:confirmed)
+  datetime(:scheduled_at)
+  ...
+end
+```
+
 ### Unique attributes
 
 If you wish to ensure unicity, you can declare a field being `:unique`:

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -394,6 +394,9 @@ defmodule Graphism do
   defmacro integer(_name, _opts \\ []) do
   end
 
+  defmacro bigint(_name, _opts \\ []) do
+  end
+
   defmacro float(_name, _opts \\ []) do
   end
 

--- a/lib/graphism/api.ex
+++ b/lib/graphism/api.ex
@@ -728,7 +728,6 @@ defmodule Graphism.Api do
           end)
         end
       end
-      |> Ast.print(e[:name] == :feature)
 
     [fun | funs]
   end

--- a/lib/graphism/entity.ex
+++ b/lib/graphism/entity.ex
@@ -115,7 +115,10 @@ defmodule Graphism.Entity do
 
   def boolean?(attr), do: attr[:kind] == :boolean
   def enum?(attr), do: attr[:opts][:one_of] != nil
-  def attr_graphql_type(attr), do: attr[:opts][:one_of] || attr[:kind]
+  def attr_graphql_type(attr), do: attr[:opts][:one_of] || graphql_data_type(attr[:kind])
+  defp graphql_data_type(:bigint), do: :integer
+  defp graphql_data_type(other), do: other
+
   def has_default?(attr), do: Keyword.has_key?(attr[:opts], :default)
 
   defp modifier?(any, modifier), do: any |> modifiers() |> Enum.member?(modifier)
@@ -768,6 +771,7 @@ defmodule Graphism.Entity do
   def attribute({:string, _, [name]}), do: attribute([name, :string])
   def attribute({:text, _, [name]}), do: attribute([name, :string, [store: :text]])
   def attribute({:integer, _, [name]}), do: attribute([name, :integer])
+  def attribute({:bigint, _, [name]}), do: attribute([name, :bigint])
   def attribute({:boolean, _, [name]}), do: attribute([name, :boolean])
   def attribute({:float, _, [name]}), do: attribute([name, :float])
   def attribute({:datetime, _, [name]}), do: attribute([name, :datetime])

--- a/lib/graphism/schema.ex
+++ b/lib/graphism/schema.ex
@@ -426,6 +426,7 @@ defmodule Graphism.Schema do
     end
   end
 
+  defp ecto_datatype(:bigint), do: :integer
   defp ecto_datatype(:datetime), do: :utc_datetime
   defp ecto_datatype(other), do: other
 


### PR DESCRIPTION
### Description

Support for bigint attributes

```elixir
entity :my_app  do
  bigint(:active_users)
end
```

 In reality, bigint is just a database concept, so this attribute type will be seen as a plain integer in GraphQL and Elixir. However database migrations will create the postgres' `bigint` type

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
