### PR TITLE
Explicit inverse relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Explicit inverse relations - [#160](https://github.com/Otion-Core/graphism/pull/160)
+
 # v0.16.0 (Sep 20th, 2024)
 
 - New scopes - [#157](https://github.com/Otion-Core/graphism/pull/157)

--- a/README.md
+++ b/README.md
@@ -277,6 +277,37 @@ entity :post do
 end
 ```
 
+
+### Relations
+
+Graphism ony supports two types of relations: `belongs_to` and `has_many`. We believe these two are
+enough to cover a wide range of schema designs:
+
+
+```elixir
+entity :blog do
+  has_many(:posts)
+end
+```
+
+```elixir
+entity :post do
+  belongs_to(:post)
+end
+```
+
+The names of these relations can be customized with the `as:` keyword. Also, it is possible to
+instruct Graphim which relation is the associated `inverse:` one, wheen disambiguation is needed, eg:
+
+```elixir
+entity :node do
+  belongs_to(:node, as: left_parent)
+  belongs_to(:node, as: right_parent)
+  has_many(:node, as: left_children, inverse: :left_parent)
+  has_many(:node, as: right_children, inverse: :right_parent)
+end
+```
+
 ### Computed relations
 
 Relations can also be declared as computed in two different ways, explicitly and implicitly. Explict computed relations are declared with a `:using` hook:

--- a/lib/graphism/entity.ex
+++ b/lib/graphism/entity.ex
@@ -184,20 +184,30 @@ defmodule Graphism.Entity do
   end
 
   def inverse_relation(schema, e, name) do
+    entity_name = e[:name]
     rel = relation!(e, name)
+    inverse_name = get_in(rel, [:opts, :inverse])
     target = find_entity!(schema, rel[:target])
 
     case rel[:kind] do
       :has_many ->
         target
         |> parent_relations()
-        |> Enum.find(fn rel -> rel[:target] == e[:name] end)
+        |> relation_by_target(entity_name, inverse_name)
 
       :belongs_to ->
         target
         |> child_relations()
-        |> Enum.find(fn rel -> rel[:target] == e[:name] end)
+        |> relation_by_target(entity_name, inverse_name)
     end
+  end
+
+  defp relation_by_target(rels, target, nil) do
+    Enum.find(rels, fn rel -> rel[:target] == target end)
+  end
+
+  defp relation_by_target(rels, target, name) do
+    Enum.find(rels, fn rel -> rel[:target] == target && rel[:name] == name end)
   end
 
   def inverse_relation_if_exists(schema, e, name) do


### PR DESCRIPTION
# Description

Adds support for the `inverse:` keyword in `belongs_to` and `has_many` relations, so that Graphism is able to better identify what the inverse relation is in order to build the ecto schema more accurately. 
